### PR TITLE
Minutes from 16 Nov 2020 and actions

### DIFF
--- a/charter.adoc
+++ b/charter.adoc
@@ -16,7 +16,7 @@ Document conventions:
 
 == Overview
 
-This document is a draft for review pending final approval by the SIG membership at its meeting on 16 November 2020.  It will then be submitted for ratification by the Technical Steering Committee.
+This document has been approved by the SIG membership at its meeting on 16 November 2020.  It awaits ratification by the Technical Steering Committee.
 
 == Scope
 
@@ -60,7 +60,7 @@ The types of proposals we might create are.
 
 3. Areas where processes need creating or improving. I have given an example of a process to establish vendor specific relocations, in order that we can have vendor specific tool chains that are consistent.
 
-For things that are of modest scope and generally of value the work might be commissioned by RISC-V International. However for larger projects we might have an additional role, which is to help formation of industry consortia to commission the work. An example of this might be delivery of optimizing Fortran compiler support in GCC and/or LLVM, something that is critical to the small number of RISC-V International members who are in the HPC space, and which represents tens of engineer years of work over an extended period.
+For things that are of modest scope and generally of value the work might be commissioned by RISC-V International. However for larger projects we might have an additional role, which is to help formation of industry consortia to commission the work. An example of this might be delivery of optimizing Fortran compiler support in GCC and/or LLVM, something that is critical to the small number of RISC-V International members who are in the HPC space, and which represents tens of engineer years of work over an extended period.  Any such consortium formation will be carried out in a completely neutral fashion, following all anti-trust rules.
 
 Some of these areas overlap with other groups, notably the Code Size Reduction SIG (compiler and library issues), the Managed Runtimes SIG (interpreted and JITable languages) and J-extension TG (pointer masking and sandboxing may be overlap areas). We shall communicate regularly with these groups, and agree who will lead on any overlapping issues.
 
@@ -80,5 +80,11 @@ Initial version for discussion.
 Jeremy Bennett |
 
 Draft for review, incorporating comments from initial meeting and pending finalization on 16 November 2020.
+
+| 0.90      | 16 November 2020  |
+
+Jeremy Bennett |
+
+Final version approved by the meeting of 16 November to submit for ratification by TSC.
 
 |================================================================================

--- a/meetings/2020-11-16-minutes.adoc
+++ b/meetings/2020-11-16-minutes.adoc
@@ -1,0 +1,120 @@
+:leveloffset: 1
+= RISC-V Code Speed Optimization SIG Meeting Minutes =
+
+Monday 16 November 2020, 07:00 Pacific Time
+
+////
+SPDX-License-Identifier: CC-BY-4.0
+
+Document conventions:
+- one line per paragraph (don't fill lines - this makes changes clearer)
+- Wikipedia heading conventions (First word only capitalized)
+- US spelling throughout.
+////
+
+== Summary of actions
+
+* **Jeremy Bennett.** Clarify wording around faciliating consortia.
+* **Jeremy Bennett.** Submit final charter to TWG for ratification.
+* **Jeremy Bennett.** Advise Toolchain & Runtimes SC they need to own the list of software maintained by RISC-V International.
+* **Jeremy Bennett.** Update list of potential projects.
+* **Jeremy Bennett.** Advise Toolchain & Runtimes SC that they need to track libraries of interest to RISC-V International.
+
+== Review of actions
+
+* *Mark Himelstein* to advise how to access the free advertising for the commercial ecosystem
+
+** complete - information circulated via the mailing list.
+
+* *Jeremy Bennett* to collect comments on the charter and prepare an updated version for the next weeting.
+
+** complete
+
+* *Jeremy Bennett* to create the candidate project list in GitHub, so it can be updated by pull request and issue submission.
+
+** complete.
+
+* *Jim Wilson* to provide his list of GCC improvements.
+
+** complete.
+
+== Welcome
+
+Attendees introduced themselves.
+
+== Review the charter
+
+Question of whether we can facilitate as a consortium. Probably need to do by escalation. Forming consortia would need to be outside RISC-V International.
+
+**ACTION:** Jeremy Bennett. Clarify wording around faciliating consortia.
+
+Subject to clarification of the point above, approved _nem. con._
+
+**ACTION:** Jeremy Bennett. Submit final charter to TSC for ratification.
+
+== List of candidate projects
+
+Add the following.
+
+* lots of language support. Set up baseline of code speed for each language
+
+** see RISC-V software list maintained by RISC-V International
+** This should be owned by Toolchain & Runtimes SC
+** **ACTION:** Jeremy Bennett. Advise Toolchain & Runtimes SC they need to own the list of software maintained by RISC-V International
+** Chinese Academy of Sciences PLCT Lab have infrastructure
+
+* need list of benchmarks (see existing proposed project).
+
+* loop level profiling, compilers support for profiling
+
+* how does code density affect code speed, including cache impacts
+
+* LLVM optimizations
+
+* Other compiler optimizations
+
+**ACTION:** Jeremy Bennett. Update list of potential projects.
+
+=== Prioritization
+
+Each person present was asked to choose their top two priorities for projects to work on
+
+[cols="<4,>1",options="header,pagewidth",]
+|=============================================================================
+| _Project_                                                 | _Count_
+| Continuous integration and test, benchmarking and tracing |      8
+| Compiler optimizations for upcoming extensions            |      7
+| Allocation of vendor specific relocations                 |      3
+| GCC optimizations                                         |      2
+| Linker related optimization                               |      2
+| Documentation                                             |      1
+| Making best use of existing optimizations                 |      1
+|=============================================================================
+
+At our next meeting we will tackle the first two of these
+
+- **Wei Wu** (co-chair) will lead the discussion on continuous integration adn test, benchmarking and tracing
+- **Jeremy Bennett** (chair) will led the discussion on compiler optimizations for upcoming extensions
+
+== Dates of future meetings
+
+The group meets at 07:00 Pacific Time
+
+- Monday 7 December 2020
+- Thereafter first Monday of the month throughout 2021
+
+Mark Himelstein noted we can have more meetings if we need to.
+
+== AOB
+
+News from Chinese Academy of Sciences PLCT Lab
+
+- Now have OpenJDK with basic RV64G porting. 50KLOC.
+- Working on optimization OpenCV.
+
+The SIG's role is to optimize libraries for speed, however there is a wider question of tracking which libraries matter to RISC-V International.
+
+**ACTION:** Jeremy Bennett.  Advice Toolchain & Runtimes SC that they need to track libraries of interest to RISC-V.
+
+Jeremy Bennett, Candidate Chair +
+Wei Wu, Candidate Co-chair

--- a/projects/candidate-projects.adoc
+++ b/projects/candidate-projects.adoc
@@ -22,12 +22,17 @@ Some of these may be handled by other groups. Please submit pull requests or iss
 - compiler (GCC/LLVM/IAR) optimization for upcoming extensions (B, V, P, J, etc)
 - machine learning outside the compiler
 - superoptimization
+- compiler support for profiling, including loop level profiling
+- general LLVM optimizations
+- general optimizations for other compilers
+- `-menable-experimental-extensions` option for GCC
 
 == Process
 
 - FSF copyright assignment in RISC-V mirror repositories
 - allocation of vendor specific linker relocations
-- `-menable-experimental-extensions` option for GCC
-- ongoing benchmarking (and regressions in benchmarking), including competitive analysis
+- ongoing benchmarking (and regressions in benchmarking), including competitive analysis, identifying suitable benchmarks to use and support for tracing
+- determination of baseline code speed benchmarks for each language supported by RISC-V
 - documentation, for example to facilitate writing a scheduler, what can be standardize/parameterized, what are the "hints" in RISC-V documentation
-- buildbot infrastructure for open source CI and measurement
+- buildbot infrastructure for open source CI and measurement (tied into benchmarking and tracing)
+- determine the impact of code density on code speed, including cache impacts


### PR DESCRIPTION
	Two actions are met in this commit, updating the charter and
	updating the list of candidate projects.

Files changed:

	* charter.adoc: Note this is ratified by the membership; note
	obligation to comply with anti-trust rules; update version number
	to 0.9.
	* meetings/2020-11-16-minutes.adoc: Created.
	* projects/candidate-projects.adoc: New projects added in light of
	meeting on 16 November.

Signed-off-by: Jeremy Bennett <jeremy.bennett@embecosm.com>