### PR TITLE
Add participate info

### DIFF
--- a/projects/gcc-optimizations.adoc
+++ b/projects/gcc-optimizations.adoc
@@ -37,6 +37,8 @@ I attached my patches so you can see what I was doing.  These are old patches so
 
 I have a bunch of other unfinished patches, but there was never anyone available to help me with them, or anyone I could talk to about them.  Maybe this can be brought up in the new code optimization task group.
 
+(Jiawei is working on it)
+
 === Files
 
 Patches:


### PR DESCRIPTION
Add participate info with "Exposing SImode operations to the RTL expanders for `any_bitwise` on RV64" optimate.